### PR TITLE
Implement MiraNet schema

### DIFF
--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -544,13 +544,25 @@ class ACSet:
 
         return acs
 
-    def write_json(self):
+    def to_json_obj(self):
+        """Serialize the ACSet to a JSON object.
+
+        Returns:
+            The JSON object of the serialized ACSet.
+        """
+        return self.export_pydantic().dict()
+
+    def to_json_file(self, fname, *args, **kwargs):
+        with open(fname, 'w') as fh:
+            fh.write(self.write_json(*args, **kwargs))
+
+    def write_json(self, *args, **kwargs):
         """Serialize the ACSet to a JSON string.
 
         Returns:
             The JSON string of the serialized ACSet.
         """
-        return self.export_pydantic().json()
+        return self.export_pydantic().json(*args, **kwargs)
 
     @classmethod
     def read_json(cls, name: str, schema: Schema, s: str):

--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -417,7 +417,7 @@ class ACSet:
             f: The `Hom` or `Attr` to modify.
             x: A valid type for the given `Hom` or `Attr` to set the value or `None` to delete the property.
         """
-        if x == None:
+        if x is None:
             if self.has_subpart(i, f):
                 del self._subparts[f][i]
         else:
@@ -553,10 +553,15 @@ class ACSet:
         return self.export_pydantic().dict()
 
     def to_json_file(self, fname, *args, **kwargs):
-        with open(fname, 'w') as fh:
-            fh.write(self.write_json(*args, **kwargs))
+        """Serialize the ACSet to a JSON file.
 
-    def write_json(self, *args, **kwargs):
+        Args:
+            fname: The file name to write the JSON to.
+        """
+        with open(fname, 'w') as fh:
+            fh.write(self.to_json_str(*args, **kwargs))
+
+    def to_json_str(self, *args, **kwargs):
         """Serialize the ACSet to a JSON string.
 
         Returns:
@@ -569,6 +574,7 @@ class ACSet:
         """Deserialize a JSON string to an ACSet with a given `Schema`.
 
         Args:
+            name: The name of the ACSset.
             schema: The `Schema` of the ACSet that is defined in the given JSON.
             s: The JSON string
 

--- a/src/acsets/mira.py
+++ b/src/acsets/mira.py
@@ -1,5 +1,10 @@
+"""
+This module implements a schema for what we call MiraNet, an extension
+of the Petri net model with additional attributes and metadata.
+"""
+
 from .petris import Petri
-from .acsets import ACSet, Attr, AttrType, Hom, Ob, Schema
+from .acsets import Attr, AttrType, Hom, Ob, Schema
 
 Species = Ob("S")
 Transition = Ob("T")
@@ -46,8 +51,11 @@ SchMira = Schema(
            attr_parameters],
 )
 
-class MiraNet(Petri):
 
+class MiraNet(Petri):
+    """A subclass of Petri customized for MiraNet."""
     schema = SchMira
+
     def __init__(self, name="MiraNet", schema=SchMira):
+        """Initialize a new MiraNet."""
         super(MiraNet, self).__init__(name, schema)

--- a/src/acsets/mira.py
+++ b/src/acsets/mira.py
@@ -26,8 +26,8 @@ attr_concept = Attr("mira_concept", Species, JsonStr)
 attr_initial = Attr("mira_initial_value", Species, Value)
 
 # Transition attributes
-attr_pname = Attr("pname", Transition, Name)
-attr_pval = Attr("pval", Transition, Value)
+attr_pname = Attr("parameter_name", Transition, Name)
+attr_pval = Attr("parameter_value", Transition, Value)
 attr_tname = Attr("tname", Transition, Name)
 attr_rate_law = Attr("mira_rate_law", Transition, SymPyStr)
 attr_rate_mathml = Attr("mira_rate_law_mathml", Transition, XmlStr)

--- a/src/acsets/mira.py
+++ b/src/acsets/mira.py
@@ -26,9 +26,10 @@ attr_concept = Attr("mira_concept", Species, JsonStr)
 attr_initial = Attr("mira_initial_value", Species, Value)
 
 # Transition attributes
+attr_tname = Attr("tname", Transition, Name)
 attr_pname = Attr("parameter_name", Transition, Name)
 attr_pval = Attr("parameter_value", Transition, Value)
-attr_tname = Attr("tname", Transition, Name)
+attr_template_type = Attr("template_type", Transition, Name)
 attr_rate_law = Attr("mira_rate_law", Transition, SymPyStr)
 attr_rate_mathml = Attr("mira_rate_law_mathml", Transition, XmlStr)
 attr_template = Attr("mira_template", Transition, JsonStr)
@@ -41,7 +42,7 @@ SchMira = Schema(
     attrtypes=[Name, Value, JsonStr, XmlStr, SymPyStr],
     attrs=[attr_sname, attr_tname, attr_pname, attr_pval,
            attr_ids, attr_context, attr_concept, attr_initial,
-           attr_rate_law, attr_rate_mathml, attr_template,
+           attr_template_type, attr_rate_law, attr_rate_mathml, attr_template,
            attr_parameters],
 )
 

--- a/src/acsets/mira.py
+++ b/src/acsets/mira.py
@@ -1,0 +1,52 @@
+from .petris import Petri
+from .acsets import ACSet, Attr, AttrType, Hom, Ob, Schema
+
+Species = Ob("S")
+Transition = Ob("T")
+Input = Ob("I")
+Output = Ob("O")
+
+hom_it = Hom("it", Input, Transition)
+hom_is = Hom("is", Input, Species)
+hom_ot = Hom("ot", Output, Transition)
+hom_os = Hom("os", Output, Species)
+
+# Attribute types
+Name = AttrType("Name", str)
+Value = AttrType("Value", float)
+JsonStr = AttrType("JsonStr", str)
+XmlStr = AttrType("XmlStr", str)
+SymPyStr = AttrType("SymPyStr", str)
+
+# Species attributes
+attr_sname = Attr("sname", Species, Name)
+attr_ids = Attr("mira_ids", Species, JsonStr)
+attr_context = Attr("mira_context", Species, JsonStr)
+attr_concept = Attr("mira_concept", Species, JsonStr)
+attr_initial = Attr("mira_initial_value", Species, Value)
+
+# Transition attributes
+attr_pname = Attr("pname", Transition, Name)
+attr_pval = Attr("pval", Transition, Value)
+attr_tname = Attr("tname", Transition, Name)
+attr_rate_law = Attr("mira_rate_law", Transition, SymPyStr)
+attr_rate_mathml = Attr("mira_rate_law_mathml", Transition, XmlStr)
+attr_template = Attr("mira_template", Transition, JsonStr)
+attr_parameters = Attr("mira_parameters", Transition, JsonStr)
+
+SchMira = Schema(
+    name="MiraNet",
+    obs=[Species, Transition, Input, Output],
+    homs=[hom_it, hom_is, hom_ot, hom_os],
+    attrtypes=[Name, Value, JsonStr, XmlStr, SymPyStr],
+    attrs=[attr_sname, attr_tname, attr_pname, attr_pval,
+           attr_ids, attr_context, attr_concept, attr_initial,
+           attr_rate_law, attr_rate_mathml, attr_template,
+           attr_parameters],
+)
+
+class MiraNet(Petri):
+
+    schema = SchMira
+    def __init__(self, name="MiraNet", schema=SchMira):
+        super(MiraNet, self).__init__(name, schema)

--- a/tests/test_petri.py
+++ b/tests/test_petri.py
@@ -17,12 +17,12 @@ class TestSerialization(unittest.TestCase):
         inf, rec = sir.add_transitions([([s, i], [i, i]), ([i], [r])])
 
         pd_sir = sir.export_pydantic()
-        serialized = sir.write_json()
+        serialized = sir.to_json_str()
         deserialized = petris.Petri.import_pydantic("Petri", petris.SchPetri, pd_sir)
         pd_sir2 = deserialized.export_pydantic()
-        reserialized = deserialized.write_json()
+        reserialized = deserialized.to_json_str()
         deserialized2 = petris.Petri.read_json("Petri", petris.SchPetri, reserialized)
-        rereserialized = deserialized2.write_json()
+        rereserialized = deserialized2.to_json_str()
 
         self.assertEqual(pd_sir2, pd_sir)
         self.assertEqual(serialized, reserialized)


### PR DESCRIPTION
This PR adds an implementation of MiraNet to codify the current state of how we have been serializing MIRA models into a schema that extends the Petri schema in this repo. One example of a JSON-serialized model that this class can now handle is this model from the evaluation: https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_2/scenario3_biomd958.json.

The PR also adds a couple of simple convenience functions to the ACSet class for handling JSON content.