### PR TITLE
Enable writing JSON schema

### DIFF
--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -5,6 +5,7 @@ In this module, we define schemas and acsets.
 import json
 from typing import Any, Union
 
+import pydantic.schema
 from pydantic import BaseModel, create_model
 
 
@@ -263,6 +264,20 @@ class Schema:
         self.model = create_model(
             self.name, **{ob.name: (list[ob_models[ob]], ...) for ob in self.obs}  # type: ignore
         )
+
+    def make_schema(self, uri: Optional[str] = None, description: Optional[str] = None):
+        """Make a JSON schema dictionary object representing this schema.
+
+        :param uri: The URI where the JSON file that corresponds to this schema lives
+        :param description: A description of this schema
+        :returns: A dictionary with the JSON schema inside it that can be written with
+            :func:`json.dump`.
+        """
+        schema = pydantic.schema.schema([self.model], title=self.name, description=description)
+        schema["$schema"] = "http://json-schema.org/draft-07/schema#"
+        if uri is not None:
+            schema["$id"] = uri
+        return schema
 
     @property
     def obs(self):

--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -3,10 +3,14 @@ In this module, we define schemas and acsets.
 """
 
 import json
-from typing import Any, Union
+from pathlib import Path
+from typing import Any, Optional, Union
 
 import pydantic.schema
 from pydantic import BaseModel, create_model
+
+HERE = Path(__file__).parent.resolve()
+SCHEMAS_DIRECTORY = HERE.joinpath("schemas")
 
 
 class HashableBaseModel(BaseModel):
@@ -265,19 +269,30 @@ class Schema:
             self.name, **{ob.name: (list[ob_models[ob]], ...) for ob in self.obs}  # type: ignore
         )
 
-    def make_schema(self, uri: Optional[str] = None, description: Optional[str] = None):
+    def make_schema(self, uri: Optional[str] = None):
         """Make a JSON schema dictionary object representing this schema.
 
         :param uri: The URI where the JSON file that corresponds to this schema lives
-        :param description: A description of this schema
         :returns: A dictionary with the JSON schema inside it that can be written with
             :func:`json.dump`.
         """
-        schema = pydantic.schema.schema([self.model], title=self.name, description=description)
+        # TODO add description
+        schema = pydantic.schema.schema([self.model], title=self.name)
         schema["$schema"] = "http://json-schema.org/draft-07/schema#"
         if uri is not None:
             schema["$id"] = uri
         return schema
+
+    def write_schema(
+        self,
+        path,
+        uri: Optional[str] = None,
+    ) -> None:
+        """Write a JSON schema to a file path."""
+        schema = self.make_schema(uri=uri)
+        schema_str = json.dumps(schema, indent=2, ensure_ascii=False, sort_keys=True)
+        path = Path(path).expanduser().resolve()
+        path.write_text(schema_str)
 
     @property
     def obs(self):

--- a/src/acsets/petris.py
+++ b/src/acsets/petris.py
@@ -2,7 +2,7 @@
 In this model, we define a schema for petri nets, and then a subclass of acset
 with some convenience methods.
 """
-from acsets import ACSet, Attr, AttrType, Hom, Ob, Schema
+from acsets import ACSet, Attr, AttrType, Hom, Ob, Schema, SCHEMAS_DIRECTORY
 
 Species = Ob("S")
 Transition = Ob("T")
@@ -76,3 +76,10 @@ class Petri(ACSet):
                 self.set_subpart(arc, hom_ot, t)
                 self.set_subpart(arc, hom_os, s)
         return ts
+
+
+if __name__ == '__main__':
+    SchPetri.write_schema(
+        SCHEMAS_DIRECTORY.joinpath("petri.json"),
+        uri="https://raw.githubusercontent.com/AlgebraicJulia/py-acsets/main/src/acsets/schemas/petri.json",
+    )

--- a/src/acsets/schemas/petri.json
+++ b/src/acsets/schemas/petri.json
@@ -1,0 +1,95 @@
+{
+  "$id": "https://raw.githubusercontent.com/AlgebraicJulia/py-acsets/main/src/acsets/schemas/petri.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "I": {
+      "properties": {
+        "is": {
+          "title": "Is",
+          "type": "integer"
+        },
+        "it": {
+          "title": "It",
+          "type": "integer"
+        }
+      },
+      "title": "I",
+      "type": "object"
+    },
+    "O": {
+      "properties": {
+        "os": {
+          "title": "Os",
+          "type": "integer"
+        },
+        "ot": {
+          "title": "Ot",
+          "type": "integer"
+        }
+      },
+      "title": "O",
+      "type": "object"
+    },
+    "Petri": {
+      "properties": {
+        "I": {
+          "items": {
+            "$ref": "#/definitions/I"
+          },
+          "title": "I",
+          "type": "array"
+        },
+        "O": {
+          "items": {
+            "$ref": "#/definitions/O"
+          },
+          "title": "O",
+          "type": "array"
+        },
+        "S": {
+          "items": {
+            "$ref": "#/definitions/S"
+          },
+          "title": "S",
+          "type": "array"
+        },
+        "T": {
+          "items": {
+            "$ref": "#/definitions/T"
+          },
+          "title": "T",
+          "type": "array"
+        }
+      },
+      "required": [
+        "S",
+        "T",
+        "I",
+        "O"
+      ],
+      "title": "Petri",
+      "type": "object"
+    },
+    "S": {
+      "properties": {
+        "sname": {
+          "title": "Sname",
+          "type": "string"
+        }
+      },
+      "title": "S",
+      "type": "object"
+    },
+    "T": {
+      "properties": {
+        "tname": {
+          "title": "Tname",
+          "type": "string"
+        }
+      },
+      "title": "T",
+      "type": "object"
+    }
+  },
+  "title": "Petri"
+}


### PR DESCRIPTION
This PR adds functionality for writing a JSON schema from a `acsets.Schema` object. This builds on top of the already implemented `acsets.Schema` -> `pydantic.BaseModel` converter. 

This PR also adds the export of the petri net schema as a demo.

CC @bgyori 