### PR TITLE
Enable loading schema from JSON

### DIFF
--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -451,7 +451,7 @@ class ACSet:
 
             url = "https://github.com/AlgebraicJulia/py-acsets/blob/main/tests/petri_schema.json"
             obj = requests.get(url).json()
-            sir = ACSet.from_file(name="petri", path=path)
+            sir = ACSet.from_obj(name="petri", obj=obj)
             s, i, r = sir.add_parts("S", 3)
         """
         catlab_schema = CatlabSchema.parse_obj(obj)

--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -441,6 +441,18 @@ class ACSet:
             A JSON object representing the acset, to be
             loaded through :class:`CatlabSchema`
         :returns: An acset object
+
+        You can get an example ACSets schema definition from the testing suite
+        and load it over the web with the following code:
+
+        .. code-block:: python
+
+            import requests
+
+            url = "https://github.com/AlgebraicJulia/py-acsets/blob/main/tests/petri_schema.json"
+            obj = requests.get(url).json()
+            sir = ACSet.from_file(name="petri", path=path)
+            s, i, r = sir.add_parts("S", 3)
         """
         catlab_schema = CatlabSchema.parse_obj(obj)
         schema = Schema.from_catlab(name=name, catlab_schema=catlab_schema)

--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -3,6 +3,7 @@ In this module, we define schemas and acsets.
 """
 
 import json
+import os
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -432,14 +433,35 @@ class ACSet:
 
     @classmethod
     def from_obj(cls, *, name: str, obj) -> "ACSet":
-        """Make an ACSet from a JSON object representing its schema."""
+        """Make an ACSet from a JSON object representing its schema.
+
+        :param name: The name of the acset
+        :param obj:
+            A JSON object representing the acset, to be
+            loaded through :class:`CatlabSchema`
+        :returns: An acset object
+        """
         catlab_schema = CatlabSchema.parse_obj(obj)
         schema = Schema.from_catlab(name=name, catlab_schema=catlab_schema)
         return cls(name=name, schema=schema)
 
     @classmethod
-    def from_file(cls, *, name: str, path) -> "ACSet":
-        """Make an ACSet from a file with the JSON representing its schema."""
+    def from_file(cls, *, name: str, path: os.PathLike) -> "ACSet":
+        """Make an ACSet from a file with the JSON representing its schema.
+
+        :param name: The name of the acset
+        :param path: A path to the file
+        :returns: An acset object
+
+        For example, if you have a JSON file representing the Petri Net
+        schema, you can load it and start working with:
+
+        .. code-block:: python
+
+            path = ...
+            sir = ACSet.from_file(name="petri", path=path)
+            s, i, r = sir.add_parts("S", 3)
+        """
         with open(path) as file:
             obj = json.load(file)
         return cls.from_obj(name=name, obj=obj)

--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -428,6 +428,7 @@ class ACSet:
         self.schema = schema
         self._parts = {ob: 0 for ob in schema.obs}
         self._subparts = {f: {} for f in schema.homs + schema.attrs}
+        self._name_to_ob = {ob.name: ob for ob in schema.obs}
 
     @classmethod
     def from_obj(cls, *, name: str, obj) -> "ACSet":
@@ -443,7 +444,7 @@ class ACSet:
             obj = json.load(file)
         return cls.from_obj(name=name, obj=obj)
 
-    def add_parts(self, ob: Ob, n: int) -> range:
+    def add_parts(self, ob: Union[str, Ob], n: int) -> range:
         """Add `n` parts to an object in the ACset.
 
         Args:
@@ -453,12 +454,14 @@ class ACSet:
         Returns:
             A range of the indexes of the new parts added to the object.
         """
+        if isinstance(ob, str):
+            ob = self._name_to_ob[ob]
         assert ob in self.schema.obs
         i = self._parts[ob]
         self._parts[ob] += n
         return range(i, i + n)
 
-    def add_part(self, ob: Ob) -> int:
+    def add_part(self, ob: Union[str, Ob]) -> int:
         """Add a single part to an object in the ACSet
 
         Args:

--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -5,7 +5,7 @@ In this module, we define schemas and acsets.
 import json
 import os
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Mapping, Optional, Union
 
 import pydantic.schema
 from pydantic import BaseModel, Field, create_model, validator
@@ -417,6 +417,7 @@ class ACSet:
     schema: Schema
     _parts: dict[Ob, int]
     _subparts: dict[Property, dict[int, Any]]
+    _name_to_ob: Mapping[str, Ob]
 
     def __init__(self, name: str, schema: Schema):
         """Initialize a new ACSet.

--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -146,6 +146,8 @@ class Attr(HashableBaseModel):
         Returns:
             The type that the attribute maps to.
         """
+        if self.codom.ty_cls is None:
+            raise RuntimeError
         return self.codom.ty_cls
 
     class Config:

--- a/src/acsets/mira.py
+++ b/src/acsets/mira.py
@@ -7,9 +7,9 @@ from .acsets import Attr, AttrType, Hom, Ob, Schema
 from .petris import Petri
 
 Species = Ob(name="S", title="Species")
-Transition = Ob("T", title="Transition")
-Input = Ob("I", title="Input")
-Output = Ob("O", title="Output")
+Transition = Ob(name="T", title="Transition")
+Input = Ob(name="I", title="Input")
+Output = Ob(name="O", title="Output")
 
 hom_it = Hom(name="it", dom=Input, codom=Transition, title="Input transition morphism")
 hom_is = Hom(name="is", dom=Input, codom=Species, title="Input species morphism")
@@ -20,7 +20,9 @@ hom_os = Hom(name="os", dom=Output, codom=Species, title="Output species morphis
 Name = AttrType(name="Name", ty=str, title="Name")
 Value = AttrType(name="Value", ty=float)
 JsonStr = AttrType(name="JsonStr", ty=str, description="A string a serialized JSON object")
-XmlStr = AttrType("XmlStr", ty=str, description="A string representing an XML object as a string")
+XmlStr = AttrType(
+    name="XmlStr", ty=str, description="A string representing an XML object as a string"
+)
 SymPyStr = AttrType(
     name="SymPyStr",
     ty=str,

--- a/src/acsets/mira.py
+++ b/src/acsets/mira.py
@@ -3,57 +3,69 @@ This module implements a schema for what we call MiraNet, an extension
 of the Petri net model with additional attributes and metadata.
 """
 
-from .petris import Petri
 from .acsets import Attr, AttrType, Hom, Ob, Schema
+from .petris import Petri
 
-Species = Ob("S")
-Transition = Ob("T")
-Input = Ob("I")
-Output = Ob("O")
+Species = Ob(name="S")
+Transition = Ob(name="T")
+Input = Ob(name="I")
+Output = Ob(name="O")
 
-hom_it = Hom("it", Input, Transition)
-hom_is = Hom("is", Input, Species)
-hom_ot = Hom("ot", Output, Transition)
-hom_os = Hom("os", Output, Species)
+hom_it = Hom(name="it", dom=Input, codom=Transition)
+hom_is = Hom(name="is", dom=Input, codom=Species)
+hom_ot = Hom(name="ot", dom=Output, codom=Transition)
+hom_os = Hom(name="os", dom=Output, codom=Species)
 
 # Attribute types
-Name = AttrType("Name", str)
-Value = AttrType("Value", float)
-JsonStr = AttrType("JsonStr", str)
-XmlStr = AttrType("XmlStr", str)
-SymPyStr = AttrType("SymPyStr", str)
+Name = AttrType(name="Name", ty=str)
+Value = AttrType(name="Value", ty=float)
+JsonStr = AttrType(name="JsonStr", ty=str)
+XmlStr = AttrType(name="XmlStr", ty=str)
+SymPyStr = AttrType(name="SymPyStr", ty=str)
 
 # Species attributes
-attr_sname = Attr("sname", Species, Name)
-attr_ids = Attr("mira_ids", Species, JsonStr)
-attr_context = Attr("mira_context", Species, JsonStr)
-attr_concept = Attr("mira_concept", Species, JsonStr)
-attr_initial = Attr("mira_initial_value", Species, Value)
+attr_sname = Attr(name="sname", dom=Species, codom=Name)
+attr_ids = Attr(name="mira_ids", dom=Species, codom=JsonStr)
+attr_context = Attr(name="mira_context", dom=Species, codom=JsonStr)
+attr_concept = Attr(name="mira_concept", dom=Species, codom=JsonStr)
+attr_initial = Attr("mira_initial_value", dom=Species, codom=Value)
 
 # Transition attributes
-attr_tname = Attr("tname", Transition, Name)
-attr_pname = Attr("parameter_name", Transition, Name)
-attr_pval = Attr("parameter_value", Transition, Value)
-attr_template_type = Attr("template_type", Transition, Name)
-attr_rate_law = Attr("mira_rate_law", Transition, SymPyStr)
-attr_rate_mathml = Attr("mira_rate_law_mathml", Transition, XmlStr)
-attr_template = Attr("mira_template", Transition, JsonStr)
-attr_parameters = Attr("mira_parameters", Transition, JsonStr)
+attr_tname = Attr(name="tname", dom=Transition, codom=Name)
+attr_pname = Attr(name="parameter_name", dom=Transition, codom=Name)
+attr_pval = Attr(name="parameter_value", dom=Transition, codom=Value)
+attr_template_type = Attr(name="template_type", dom=Transition, codom=Name)
+attr_rate_law = Attr(name="mira_rate_law", dom=Transition, codom=SymPyStr)
+attr_rate_mathml = Attr(name="mira_rate_law_mathml", dom=Transition, codom=XmlStr)
+attr_template = Attr(name="mira_template", dom=Transition, codom=JsonStr)
+attr_parameters = Attr(name="mira_parameters", dom=Transition, codom=JsonStr)
 
 SchMira = Schema(
     name="MiraNet",
     obs=[Species, Transition, Input, Output],
     homs=[hom_it, hom_is, hom_ot, hom_os],
     attrtypes=[Name, Value, JsonStr, XmlStr, SymPyStr],
-    attrs=[attr_sname, attr_tname, attr_pname, attr_pval,
-           attr_ids, attr_context, attr_concept, attr_initial,
-           attr_template_type, attr_rate_law, attr_rate_mathml, attr_template,
-           attr_parameters],
+    attrs=[
+        attr_sname,
+        attr_tname,
+        attr_pname,
+        attr_pval,
+        attr_ids,
+        attr_context,
+        attr_concept,
+        attr_initial,
+        attr_template_type,
+        attr_rate_law,
+        attr_rate_mathml,
+        attr_template,
+        attr_parameters,
+    ],
 )
 
 
 class MiraNet(Petri):
     """A subclass of Petri customized for MiraNet."""
+
     schema = SchMira
 
     def __init__(self, name="MiraNet", schema=SchMira):

--- a/src/acsets/petris.py
+++ b/src/acsets/petris.py
@@ -66,7 +66,7 @@ class Petri(ACSet):
             A range of the of the indexes of the transitions that were inserted into the petri net.
         """
         ts = self.add_parts(Transition, len(transitions))
-        for (t, (ins, outs)) in zip(ts, transitions):
+        for t, (ins, outs) in zip(ts, transitions):
             for s in ins:
                 arc = self.add_part(Input)
                 self.set_subpart(arc, hom_it, t)

--- a/src/acsets/petris.py
+++ b/src/acsets/petris.py
@@ -4,20 +4,20 @@ with some convenience methods.
 """
 from acsets import ACSet, Attr, AttrType, Hom, Ob, Schema
 
-Species = Ob("S")
-Transition = Ob("T")
-Input = Ob("I")
-Output = Ob("O")
+Species = Ob(name="S")
+Transition = Ob(name="T")
+Input = Ob(name="I")
+Output = Ob(name="O")
 
-hom_it = Hom("it", Input, Transition)
-hom_is = Hom("is", Input, Species)
-hom_ot = Hom("ot", Output, Transition)
-hom_os = Hom("os", Output, Species)
+hom_it = Hom(name="it", dom=Input, codom=Transition)
+hom_is = Hom(name="is", dom=Input, codom=Species)
+hom_ot = Hom(name="ot", dom=Output, codom=Transition)
+hom_os = Hom(name="os", dom=Output, codom=Species)
 
-Name = AttrType("Name", str)
+Name = AttrType(name="Name", ty=str)
 
-attr_sname = Attr("sname", Species, Name)
-attr_tname = Attr("tname", Transition, Name)
+attr_sname = Attr(name="sname", dom=Species, codom=Name)
+attr_tname = Attr(name="tname", dom=Transition, codom=Name)
 
 SchPetri = Schema(
     "Petri",

--- a/tests/petri_schema.json
+++ b/tests/petri_schema.json
@@ -1,0 +1,86 @@
+{
+  "attrs": [
+    {
+      "codom": {
+        "name": "Name",
+        "ty": "str"
+      },
+      "dom": {
+        "name": "S"
+      },
+      "name": "sname"
+    },
+    {
+      "codom": {
+        "name": "Name",
+        "ty": "str"
+      },
+      "dom": {
+        "name": "T"
+      },
+      "name": "tname"
+    }
+  ],
+  "attrtypes": [
+    {
+      "name": "Name",
+      "ty": "str"
+    }
+  ],
+  "homs": [
+    {
+      "codom": {
+        "name": "T"
+      },
+      "dom": {
+        "name": "I"
+      },
+      "name": "it"
+    },
+    {
+      "codom": {
+        "name": "S"
+      },
+      "dom": {
+        "name": "I"
+      },
+      "name": "is"
+    },
+    {
+      "codom": {
+        "name": "T"
+      },
+      "dom": {
+        "name": "O"
+      },
+      "name": "ot"
+    },
+    {
+      "codom": {
+        "name": "S"
+      },
+      "dom": {
+        "name": "O"
+      },
+      "name": "os"
+    }
+  ],
+  "obs": [
+    {
+      "name": "S"
+    },
+    {
+      "name": "T"
+    },
+    {
+      "name": "I"
+    },
+    {
+      "name": "O"
+    }
+  ],
+  "version": {
+    "ACSetSchema": "0.0.1",
+    "Catlab": "0.14.12"
+  }
+}

--- a/tests/petri_schema.json
+++ b/tests/petri_schema.json
@@ -2,81 +2,87 @@
   "attrs": [
     {
       "codom": {
+        "description": null,
         "name": "Name",
+        "title": "Name",
         "ty": "str"
       },
-      "dom": {
-        "name": "S"
-      },
-      "name": "sname"
+      "description": "An attribute representing the name of a species.",
+      "dom": "S",
+      "name": "sname",
+      "title": "Species name"
     },
     {
       "codom": {
+        "description": null,
         "name": "Name",
+        "title": "Name",
         "ty": "str"
       },
-      "dom": {
-        "name": "T"
-      },
-      "name": "tname"
+      "description": "An attribute representing the name of a transition.",
+      "dom": "T",
+      "name": "tname",
+      "title": "Transition name"
     }
   ],
   "attrtypes": [
     {
+      "description": null,
       "name": "Name",
+      "title": "Name",
       "ty": "str"
     }
   ],
   "homs": [
     {
-      "codom": {
-        "name": "T"
-      },
-      "dom": {
-        "name": "I"
-      },
-      "name": "it"
+      "codom": "T",
+      "description": null,
+      "dom": "I",
+      "name": "it",
+      "title": "Input transition morphism"
     },
     {
-      "codom": {
-        "name": "S"
-      },
-      "dom": {
-        "name": "I"
-      },
-      "name": "is"
+      "codom": "S",
+      "description": null,
+      "dom": "I",
+      "name": "is",
+      "title": "Input species morphism"
     },
     {
-      "codom": {
-        "name": "T"
-      },
-      "dom": {
-        "name": "O"
-      },
-      "name": "ot"
+      "codom": "T",
+      "description": null,
+      "dom": "O",
+      "name": "ot",
+      "title": "Output transition morphism"
     },
     {
-      "codom": {
-        "name": "S"
-      },
-      "dom": {
-        "name": "O"
-      },
-      "name": "os"
+      "codom": "S",
+      "description": null,
+      "dom": "O",
+      "name": "os",
+      "title": "Output species morphism"
     }
   ],
   "obs": [
     {
-      "name": "S"
+      "description": null,
+      "name": "S",
+      "title": "Species"
     },
     {
-      "name": "T"
+      "description": null,
+      "name": "T",
+      "title": "Transition"
     },
     {
-      "name": "I"
+      "description": null,
+      "name": "I",
+      "title": "Input"
     },
     {
-      "name": "O"
+      "description": null,
+      "name": "O",
+      "title": "Output"
     }
   ],
   "version": {

--- a/tests/test_petri.py
+++ b/tests/test_petri.py
@@ -4,11 +4,34 @@
 
 import unittest
 
-from acsets import petris
+from acsets import AttrType, petris, Attr, Ob
 
 
 class TestSerialization(unittest.TestCase):
     """A test case for testing serialization."""
+
+    def test_metadata(self):
+        """Test metadata availability."""
+        schema = petris.SchPetri
+        for elements in [
+            schema.schema.obs,
+            schema.schema.homs,
+            schema.schema.attrs,
+            schema.schema.attrtypes,
+        ]:
+            for elements in elements:
+                self.assertIsNotNone(elements.name)
+
+    def test_look_up(self):
+        """Test looking up class."""
+        attr_type = AttrType(name="test", ty="str")
+        self.assertEqual(str, attr_type.ty_cls)
+
+        attr = Attr(name="test_attr", dom=Ob(name="test_ob"), codom=attr_type)
+        self.assertTrue(attr.valid_value("true!"))
+        self.assertFalse(attr.valid_value(1))
+        self.assertFalse(attr.valid_value(False))
+        self.assertFalse(attr.valid_value(1.0))
 
     def test_serialization(self):
         """Test serialization round trip."""

--- a/tests/test_petri.py
+++ b/tests/test_petri.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 import unittest
 
-from acsets import Attr, AttrType, Hom, Ob, petris
+from acsets import ACSet, Attr, AttrType, Hom, Ob, mira, petris
 
 
 class TestSerialization(unittest.TestCase):
@@ -38,21 +38,26 @@ class TestSerialization(unittest.TestCase):
 
     def test_serialization(self):
         """Test serialization round trip."""
-        sir = petris.Petri()
-        s, i, r = sir.add_species(3)
-        inf, rec = sir.add_transitions([([s, i], [i, i]), ([i], [r])])
+        for cls_name, cls, schema in [
+            ("Petri", petris.Petri, petris.SchPetri),
+            ("MiraNet", mira.MiraNet, mira.SchMira),
+        ]:
+            sir = cls()
+            self.assertIsInstance(sir, petris.Petri)
+            s, i, r = sir.add_species(3)
+            inf, rec = sir.add_transitions([([s, i], [i, i]), ([i], [r])])
 
-        pd_sir = sir.export_pydantic()
-        serialized = sir.to_json_str()
-        deserialized = petris.Petri.import_pydantic("Petri", petris.SchPetri, pd_sir)
-        pd_sir2 = deserialized.export_pydantic()
-        reserialized = deserialized.to_json_str()
-        deserialized2 = petris.Petri.read_json("Petri", petris.SchPetri, reserialized)
-        rereserialized = deserialized2.to_json_str()
+            pd_sir = sir.export_pydantic()
+            serialized = sir.to_json_str()
+            deserialized = cls.import_pydantic(cls_name, schema, pd_sir)
+            pd_sir2 = deserialized.export_pydantic()
+            reserialized = deserialized.to_json_str()
+            deserialized2 = cls.read_json(cls_name, schema, reserialized)
+            rereserialized = deserialized2.to_json_str()
 
-        self.assertEqual(pd_sir2, pd_sir)
-        self.assertEqual(serialized, reserialized)
-        self.assertEqual(reserialized, rereserialized)
+            self.assertEqual(pd_sir2, pd_sir)
+            self.assertEqual(serialized, reserialized)
+            self.assertEqual(reserialized, rereserialized)
 
     def test_ob(self):
         """Test instantiating a hom."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,29 @@
+"""Tests for schema."""
+
+import json
+import unittest
+from pathlib import Path
+
+from acsets import CatlabSchema
+from acsets.petris import SchPetri
+
+HERE = Path(__file__).parent.resolve()
+PETRI_SCHEMA_PATH = HERE.joinpath("petri_schema.json")
+
+
+class TestSchema(unittest.TestCase):
+    """Tests for the schema."""
+
+    def test_loading(self):
+        """Test loading a schema from a JSON file."""
+        schema = CatlabSchema.parse_file(PETRI_SCHEMA_PATH)
+        self.assertEqual(
+            SchPetri.schema.json(),
+            schema.json(),
+        )
+
+    def test_writing(self):
+        """Test writing a schema works as expected."""
+        expected = json.loads(PETRI_SCHEMA_PATH.read_text())
+        actual = json.loads(SchPetri.schema.json())
+        self.assertEqual(expected, actual)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -55,7 +55,5 @@ class TestSchema(unittest.TestCase):
         """Test writing, reading, then instantiating."""
         obj = json.loads(SchPetri.schema.json())
         sir = ACSet.from_obj(name="petri", obj=obj)
-        name_to_model = {ob.name: ob for ob in sir.schema.ob_models}
-        # TODO update add_parts to allow lookup based on name, not instance of Ob
-        s, i, r = sir.add_parts(name_to_model["S"], 3)
+        s, i, r = sir.add_parts("S", 3)
         self.assertIsInstance(s, int)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,7 +4,7 @@ import json
 import unittest
 from pathlib import Path
 
-from acsets import CatlabSchema
+from acsets import ACSet, Attr, AttrType, CatlabSchema, Hom, Ob, Schema
 from acsets.petris import SchPetri
 
 HERE = Path(__file__).parent.resolve()
@@ -13,6 +13,29 @@ PETRI_SCHEMA_PATH = HERE.joinpath("petri_schema.json")
 
 class TestSchema(unittest.TestCase):
     """Tests for the schema."""
+
+    def test_hom(self):
+        """Test transforming Ob objects when instantiating a Hom."""
+        ob_transition = Ob(name="T", title="Transition")
+        ob_input = Ob(name="I", title="Input")
+        hom_it = Hom(
+            name="it", dom=ob_input, codom=ob_transition, title="Input transition morphism"
+        )
+        self.assertEqual(ob_input.name, hom_it.dom)
+        self.assertEqual(ob_transition.name, hom_it.codom)
+
+    def test_attr(self):
+        """Test transforming Ob objects when instantiating an Attr."""
+        attr_type_name = AttrType(name="Name", ty=str, title="Name")
+        ob_species = Ob(name="S", title="Species")
+        attr_sname = Attr(
+            name="sname",
+            dom=ob_species,
+            codom=attr_type_name,
+            title="Species name",
+            description="An attribute representing the name of a species.",
+        )
+        self.assertEqual(ob_species.name, attr_sname.dom)
 
     def test_loading(self):
         """Test loading a schema from a JSON file."""
@@ -27,3 +50,12 @@ class TestSchema(unittest.TestCase):
         expected = json.loads(PETRI_SCHEMA_PATH.read_text())
         actual = json.loads(SchPetri.schema.json())
         self.assertEqual(expected, actual)
+
+    def test_round_trip(self):
+        """Test writing, reading, then instantiating."""
+        obj = json.loads(SchPetri.schema.json())
+        sir = ACSet.from_obj(name="petri", obj=obj)
+        name_to_model = {ob.name: ob for ob in sir.schema.ob_models}
+        # TODO update add_parts to allow lookup based on name, not instance of Ob
+        s, i, r = sir.add_parts(name_to_model["S"], 3)
+        self.assertIsInstance(s, int)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,7 @@
 """Tests for schema."""
 
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -53,7 +54,9 @@ class TestSchema(unittest.TestCase):
 
     def test_round_trip(self):
         """Test writing, reading, then instantiating."""
-        obj = json.loads(SchPetri.schema.json())
-        sir = ACSet.from_obj(name="petri", obj=obj)
-        s, i, r = sir.add_parts("S", 3)
-        self.assertIsInstance(s, int)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory).resolve().joinpath("petri.json")
+            path.write_text(SchPetri.schema.json())
+            sir = ACSet.from_file(name="petri", path=path)
+            s, i, r = sir.add_parts("S", 3)
+            self.assertIsInstance(s, int)


### PR DESCRIPTION
Based on the TA-2 meeting yesterday, this PR is about enabling Catlab schemata to be loaded and serialized to JSON, therefore enabling a platform/language-agnostic way to define a Catlab schema, which can the be implemented in each language however you want.

What this PR specifically does:

- [x] Changes use of Pydantic classes for Ob, Hom, AttrType, Attr, and CatLab schema to not implement their own `__init__` and instead rely on the one given from Pydantic. This makes it possible to load content from JSON. Note that the `Field`s aren't required, for this, but they're anice way to maintain the documentation.
- [x] Custom handling of the tricky `ty` attribute of AttrType (solved in f1585a3)
- [x] Add tests for serialization and parsing of schema JSON files based on the petri net schema

Example usage:

```python
import requests

url = "https://raw.githubusercontent.com/cthoyt/py-acsets/schema-io/tests/petri_schema.json"
obj = requests.get(url).json()
sir = ACSet.from_obj(name="petri", obj=obj)
s, i, r = sir.add_parts("S", 3)
# ... and so on
```