### PR TITLE
Define `Hom.dom` as string instead of `Ob`

### DIFF
--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -53,9 +53,9 @@ class Hom(HashableBaseModel):
 
     name: str
     dom: str
-    codom: Ob
+    codom: str
 
-    def __init__(self, name: str, dom: Union[Ob, str], codom: Ob) -> None:
+    def __init__(self, name: str, dom: Ob, codom: Ob) -> None:
         """Initialize a new morphism for a schema.
 
         Args:
@@ -63,9 +63,7 @@ class Hom(HashableBaseModel):
             dom: The object of the domain.
             codom: The object of the codomain.
         """
-        if isinstance(dom, Ob):
-            dom = dom.name
-        super(Hom, self).__init__(name=name, dom=dom, codom=codom)
+        super(Hom, self).__init__(name=name, dom=dom.name, codom=codom.name)
 
     def valid_value(self, x: Any) -> bool:
         """Check if a variable is a valid object in the morphism.
@@ -132,7 +130,7 @@ class Attr(HashableBaseModel):
     """
 
     name: str
-    dom: Ob
+    dom: str
     codom: AttrType
 
     def __init__(self, name: str, dom: Ob, codom: AttrType) -> None:
@@ -143,7 +141,7 @@ class Attr(HashableBaseModel):
             dom: The object in the domain.
             codom: The attribute type in the codomain
         """
-        super(Attr, self).__init__(name=name, dom=dom, codom=codom)
+        super(Attr, self).__init__(name=name, dom=dom.name, codom=codom)
 
     def valid_value(self, x: Any) -> bool:
         """Check if a variable is a valid type to be an attribute.
@@ -207,7 +205,6 @@ class CatlabSchema(HashableBaseModel):
 
     def __init__(
         self,
-        name: str,
         obs: list[Ob],
         homs: list[Hom],
         attrtypes: list[AttrType],
@@ -253,7 +250,7 @@ class Schema:
             attrs: A list of attributes (`Attr`).
         """
         self.name = name
-        self.schema = CatlabSchema(VERSION_SPEC, obs, homs, attrtypes, attrs)
+        self.schema = CatlabSchema(obs, homs, attrtypes, attrs)
         ob_models = {
             ob: create_model(
                 ob.name,
@@ -488,7 +485,7 @@ class ACSet:
             A list indexes.
         """
         assert f.valid_value(x)
-        return list(filter(lambda i: self.subpart(i, f) == x, self.parts(f.dom)))  # type:ignore
+        return list(filter(lambda i: self.subpart(i, f) == x, self.parts(Ob(f.dom))))
 
     def prop_dict(self, ob: Ob, i: int) -> dict[str, Any]:
         """Get a dictionary of all subparts for a given row in a table.
@@ -560,7 +557,7 @@ class ACSet:
         Args:
             fname: The file name to write the JSON to.
         """
-        with open(fname, 'w') as fh:
+        with open(fname, "w") as fh:
             fh.write(self.to_json_str(*args, **kwargs))
 
     def to_json_str(self, *args, **kwargs):

--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -488,7 +488,7 @@ class ACSet:
             A list indexes.
         """
         assert f.valid_value(x)
-        return list(filter(lambda i: self.subpart(i, f) == x, self.parts(f.dom)))
+        return list(filter(lambda i: self.subpart(i, f) == x, self.parts(f.dom)))  # type:ignore
 
     def prop_dict(self, ob: Ob, i: int) -> dict[str, Any]:
         """Get a dictionary of all subparts for a given row in a table.

--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -52,10 +52,10 @@ class Hom(HashableBaseModel):
     """
 
     name: str
-    dom: Ob
+    dom: str
     codom: Ob
 
-    def __init__(self, name: str, dom: Ob, codom: Ob) -> None:
+    def __init__(self, name: str, dom: Union[Ob, str], codom: Ob) -> None:
         """Initialize a new morphism for a schema.
 
         Args:
@@ -63,6 +63,8 @@ class Hom(HashableBaseModel):
             dom: The object of the domain.
             codom: The object of the codomain.
         """
+        if isinstance(dom, Ob):
+            dom = dom.name
         super(Hom, self).__init__(name=name, dom=dom, codom=codom)
 
     def valid_value(self, x: Any) -> bool:

--- a/tests/test_petri.py
+++ b/tests/test_petri.py
@@ -4,7 +4,7 @@
 
 import unittest
 
-from acsets import petris
+from acsets import Hom, Ob, petris
 
 
 class TestSerialization(unittest.TestCase):
@@ -27,3 +27,16 @@ class TestSerialization(unittest.TestCase):
         self.assertEqual(pd_sir2, pd_sir)
         self.assertEqual(serialized, reserialized)
         self.assertEqual(reserialized, rereserialized)
+
+    def test_ob(self):
+        """Test instantiating a hom."""
+        ob1, ob2 = Ob(name="ob1"), Ob(name="ob2")
+        hom1 = Hom(name="hom1", dom=ob1, codom=ob2)
+        self.assertIsInstance(hom1.dom, str)
+        self.assertIsInstance(hom1.codom, Ob)
+
+        hom2 = Hom(name="hom1", dom="ob1", codom=ob2)
+        self.assertIsInstance(hom2.dom, str)
+        self.assertIsInstance(hom2.codom, Ob)
+
+        self.assertEqual(hom1, hom2)

--- a/tests/test_petri.py
+++ b/tests/test_petri.py
@@ -33,10 +33,4 @@ class TestSerialization(unittest.TestCase):
         ob1, ob2 = Ob(name="ob1"), Ob(name="ob2")
         hom1 = Hom(name="hom1", dom=ob1, codom=ob2)
         self.assertIsInstance(hom1.dom, str)
-        self.assertIsInstance(hom1.codom, Ob)
-
-        hom2 = Hom(name="hom1", dom="ob1", codom=ob2)
-        self.assertIsInstance(hom2.dom, str)
-        self.assertIsInstance(hom2.codom, Ob)
-
-        self.assertEqual(hom1, hom2)
+        self.assertIsInstance(hom1.codom, str)


### PR DESCRIPTION
This is a potential solution for https://github.com/AlgebraicJulia/py-acsets/pull/14#issuecomment-1442253158. However, this relies on overriding the `__init__()` of a Pydantic class, and is therefore not so great. Later, as suggested in the other current PRs, we can switch completely to using the Pydantic-style initialization with keyword arguments then use the "post-init" hook system from Pydantic to accomplish the same thing

```python
@validator("dom", always=True)
def populate_dom(cls, v, values):
    dom = values["dom"]
    if isinstance(dom, Ob):
        dom = dom.name
    return dom
```