### PR TITLE
Fix interoperability between Catlab and Py-ACSets

### DIFF
--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -216,10 +216,10 @@ class CatlabSchema(HashableBaseModel):
     the user should use the Schema class, which is below.
     """
 
-    obs: list[Ob]
-    homs: list[Hom]
-    attrtypes: list[AttrType]
-    attrs: list[Attr]
+    Ob: list[Ob]
+    Hom: list[Hom]
+    AttrType: list[AttrType]
+    Attr: list[Attr]
     version: VersionSpec = Field(default=VERSION_SPEC)
 
     class Config:
@@ -261,7 +261,7 @@ class Schema:
         """
         self.name = name
         self.schema = CatlabSchema(
-            version=VERSION_SPEC, obs=obs, homs=homs, attrtypes=attrtypes, attrs=attrs
+            version=VERSION_SPEC, Ob=obs, Hom=homs, AttrType=attrtypes, Attr=attrs
         )
         ob_models = {
             ob: create_model(
@@ -280,10 +280,10 @@ class Schema:
         """Get a schema from a CatLab schema."""
         return cls(
             name=name,
-            obs=catlab_schema.obs,
-            homs=catlab_schema.homs,
-            attrs=catlab_schema.attrs,
-            attrtypes=catlab_schema.attrtypes,
+            obs=catlab_schema.Ob,
+            homs=catlab_schema.Hom,
+            attrs=catlab_schema.Attr,
+            attrtypes=catlab_schema.AttrType,
         )
 
     def make_schema(self, uri: Optional[str] = None):
@@ -318,7 +318,7 @@ class Schema:
         Returns:
             A list of of `Ob`\s
         """
-        return self.schema.obs
+        return self.schema.Ob
 
     @property
     def homs(self):
@@ -327,7 +327,7 @@ class Schema:
         Returns:
             A list of of `Hom`\s
         """
-        return self.schema.homs
+        return self.schema.Hom
 
     @property
     def attrtypes(self):
@@ -336,7 +336,7 @@ class Schema:
         Returns:
             A list of of `AttrType`\s
         """
-        return self.schema.attrtypes
+        return self.schema.AttrType
 
     @property
     def attrs(self):
@@ -345,7 +345,7 @@ class Schema:
         Returns:
             A list of of `Attr`\s
         """
-        return self.schema.attrs
+        return self.schema.Attr
 
     def props_outof(self, ob: Ob) -> list[Property]:
         """Get all of the properties with the domain of `ob` in the schema.

--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -7,7 +7,6 @@ import os
 from pathlib import Path
 from typing import Any, Mapping, Optional, Union
 
-import pydantic.schema
 from pydantic import BaseModel, Field, create_model, validator
 
 HERE = Path(__file__).parent.resolve()
@@ -294,7 +293,7 @@ class Schema:
             :func:`json.dump`.
         """
         # TODO add description
-        schema = pydantic.schema.schema([self.model], title=self.name)
+        schema = self.model.schema()
         schema["$schema"] = "http://json-schema.org/draft-07/schema#"
         if uri is not None:
             schema["$id"] = uri

--- a/src/acsets/schemas/petri.json
+++ b/src/acsets/schemas/petri.json
@@ -30,46 +30,6 @@
       "title": "O",
       "type": "object"
     },
-    "Petri": {
-      "properties": {
-        "I": {
-          "items": {
-            "$ref": "#/definitions/I"
-          },
-          "title": "I",
-          "type": "array"
-        },
-        "O": {
-          "items": {
-            "$ref": "#/definitions/O"
-          },
-          "title": "O",
-          "type": "array"
-        },
-        "S": {
-          "items": {
-            "$ref": "#/definitions/S"
-          },
-          "title": "S",
-          "type": "array"
-        },
-        "T": {
-          "items": {
-            "$ref": "#/definitions/T"
-          },
-          "title": "T",
-          "type": "array"
-        }
-      },
-      "required": [
-        "S",
-        "T",
-        "I",
-        "O"
-      ],
-      "title": "Petri",
-      "type": "object"
-    },
     "S": {
       "properties": {
         "sname": {
@@ -91,5 +51,42 @@
       "type": "object"
     }
   },
-  "title": "Petri"
+  "properties": {
+    "I": {
+      "items": {
+        "$ref": "#/definitions/I"
+      },
+      "title": "I",
+      "type": "array"
+    },
+    "O": {
+      "items": {
+        "$ref": "#/definitions/O"
+      },
+      "title": "O",
+      "type": "array"
+    },
+    "S": {
+      "items": {
+        "$ref": "#/definitions/S"
+      },
+      "title": "S",
+      "type": "array"
+    },
+    "T": {
+      "items": {
+        "$ref": "#/definitions/T"
+      },
+      "title": "T",
+      "type": "array"
+    }
+  },
+  "required": [
+    "S",
+    "T",
+    "I",
+    "O"
+  ],
+  "title": "Petri",
+  "type": "object"
 }

--- a/tests/petri_schema.json
+++ b/tests/petri_schema.json
@@ -1,5 +1,5 @@
 {
-  "attrs": [
+  "Attr": [
     {
       "codom": {
         "description": null,
@@ -25,7 +25,7 @@
       "title": "Transition name"
     }
   ],
-  "attrtypes": [
+  "AttrType": [
     {
       "description": null,
       "name": "Name",
@@ -33,7 +33,7 @@
       "ty": "str"
     }
   ],
-  "homs": [
+  "Hom": [
     {
       "codom": "T",
       "description": null,
@@ -63,7 +63,7 @@
       "title": "Output species morphism"
     }
   ],
-  "obs": [
+  "Ob": [
     {
       "description": null,
       "name": "S",

--- a/tests/petri_schema.json
+++ b/tests/petri_schema.json
@@ -1,24 +1,14 @@
 {
   "Attr": [
     {
-      "codom": {
-        "description": null,
-        "name": "Name",
-        "title": "Name",
-        "ty": "str"
-      },
+      "codom": "Name",
       "description": "An attribute representing the name of a species.",
       "dom": "S",
       "name": "sname",
       "title": "Species name"
     },
     {
-      "codom": {
-        "description": null,
-        "name": "Name",
-        "title": "Name",
-        "ty": "str"
-      },
+      "codom": "Name",
       "description": "An attribute representing the name of a transition.",
       "dom": "T",
       "name": "tname",

--- a/tests/test_petri.py
+++ b/tests/test_petri.py
@@ -16,10 +16,10 @@ class TestSerialization(unittest.TestCase):
         """Test metadata availability."""
         schema = petris.SchPetri
         for elements in [
-            schema.schema.obs,
-            schema.schema.homs,
-            schema.schema.attrs,
-            schema.schema.attrtypes,
+            schema.schema.Ob,
+            schema.schema.Hom,
+            schema.schema.Attr,
+            schema.schema.AttrType,
         ]:
             for elements in elements:
                 self.assertIsNotNone(elements.name)

--- a/tests/test_petri.py
+++ b/tests/test_petri.py
@@ -25,17 +25,6 @@ class TestSerialization(unittest.TestCase):
                 self.assertIsNotNone(elements.name)
                 self.assertIsNotNone(elements.title)
 
-    def test_look_up(self):
-        """Test looking up class."""
-        attr_type = AttrType(name="test", ty="str")
-        self.assertEqual(str, attr_type.ty_cls)
-
-        attr = Attr(name="test_attr", dom=Ob(name="test_ob"), codom=attr_type)
-        self.assertTrue(attr.valid_value("true!"))
-        self.assertFalse(attr.valid_value(1))
-        self.assertFalse(attr.valid_value(False))
-        self.assertFalse(attr.valid_value(1.0))
-
     def test_serialization(self):
         """Test serialization round trip."""
         for cls_name, cls, schema in [


### PR DESCRIPTION
### TODO

- [x] Fix json schema generation of ACSets (@mehalter)
- [x] Fix property names `attrs -> Attr` for example (@mehalter)
- [x] `dom` and `codom` objects should be all `string` types and we need to remove all of the `Union` types (@olynch)

Fixes #24 