### PR TITLE
Add flag for no additional properties in definitions

### DIFF
--- a/src/acsets/acsets.py
+++ b/src/acsets/acsets.py
@@ -313,6 +313,8 @@ class Schema:
         """
         # TODO add description
         schema = self.model.schema()
+        for part in schema["definitions"].values():
+            part["additionalProperties"] = False
         schema["$schema"] = "http://json-schema.org/draft-07/schema#"
         if uri is not None:
             schema["$id"] = uri

--- a/src/acsets/schemas/jsonschema/LabelledPetriNet.json
+++ b/src/acsets/schemas/jsonschema/LabelledPetriNet.json
@@ -3,6 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "I": {
+      "additionalProperties": false,
       "properties": {
         "is": {
           "title": "Is",
@@ -17,6 +18,7 @@
       "type": "object"
     },
     "O": {
+      "additionalProperties": false,
       "properties": {
         "os": {
           "title": "Os",
@@ -31,6 +33,7 @@
       "type": "object"
     },
     "S": {
+      "additionalProperties": false,
       "properties": {
         "sname": {
           "title": "Sname",
@@ -41,6 +44,7 @@
       "type": "object"
     },
     "T": {
+      "additionalProperties": false,
       "properties": {
         "tname": {
           "title": "Tname",

--- a/src/acsets/schemas/jsonschema/LabelledReactionNet.json
+++ b/src/acsets/schemas/jsonschema/LabelledReactionNet.json
@@ -3,6 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "I": {
+      "additionalProperties": false,
       "properties": {
         "is": {
           "title": "Is",
@@ -17,6 +18,7 @@
       "type": "object"
     },
     "O": {
+      "additionalProperties": false,
       "properties": {
         "os": {
           "title": "Os",
@@ -31,6 +33,7 @@
       "type": "object"
     },
     "S": {
+      "additionalProperties": false,
       "properties": {
         "concentration": {
           "title": "Concentration",
@@ -45,6 +48,7 @@
       "type": "object"
     },
     "T": {
+      "additionalProperties": false,
       "properties": {
         "rate": {
           "title": "Rate",

--- a/src/acsets/schemas/jsonschema/PetriNet.json
+++ b/src/acsets/schemas/jsonschema/PetriNet.json
@@ -3,6 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "I": {
+      "additionalProperties": false,
       "properties": {
         "is": {
           "title": "Is",
@@ -17,6 +18,7 @@
       "type": "object"
     },
     "O": {
+      "additionalProperties": false,
       "properties": {
         "os": {
           "title": "Os",
@@ -31,11 +33,13 @@
       "type": "object"
     },
     "S": {
+      "additionalProperties": false,
       "properties": {},
       "title": "S",
       "type": "object"
     },
     "T": {
+      "additionalProperties": false,
       "properties": {},
       "title": "T",
       "type": "object"

--- a/src/acsets/schemas/jsonschema/PropertyLabelledPetriNet.json
+++ b/src/acsets/schemas/jsonschema/PropertyLabelledPetriNet.json
@@ -3,6 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "I": {
+      "additionalProperties": false,
       "properties": {
         "is": {
           "title": "Is",
@@ -17,6 +18,7 @@
       "type": "object"
     },
     "O": {
+      "additionalProperties": false,
       "properties": {
         "os": {
           "title": "Os",
@@ -31,6 +33,7 @@
       "type": "object"
     },
     "S": {
+      "additionalProperties": false,
       "properties": {
         "sname": {
           "title": "Sname",
@@ -45,6 +48,7 @@
       "type": "object"
     },
     "T": {
+      "additionalProperties": false,
       "properties": {
         "tname": {
           "title": "Tname",

--- a/src/acsets/schemas/jsonschema/PropertyLabelledReactionNet.json
+++ b/src/acsets/schemas/jsonschema/PropertyLabelledReactionNet.json
@@ -3,6 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "I": {
+      "additionalProperties": false,
       "properties": {
         "is": {
           "title": "Is",
@@ -17,6 +18,7 @@
       "type": "object"
     },
     "O": {
+      "additionalProperties": false,
       "properties": {
         "os": {
           "title": "Os",
@@ -31,6 +33,7 @@
       "type": "object"
     },
     "S": {
+      "additionalProperties": false,
       "properties": {
         "concentration": {
           "title": "Concentration",
@@ -49,6 +52,7 @@
       "type": "object"
     },
     "T": {
+      "additionalProperties": false,
       "properties": {
         "rate": {
           "title": "Rate",

--- a/src/acsets/schemas/jsonschema/PropertyPetriNet.json
+++ b/src/acsets/schemas/jsonschema/PropertyPetriNet.json
@@ -3,6 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "I": {
+      "additionalProperties": false,
       "properties": {
         "is": {
           "title": "Is",
@@ -17,6 +18,7 @@
       "type": "object"
     },
     "O": {
+      "additionalProperties": false,
       "properties": {
         "os": {
           "title": "Os",
@@ -31,6 +33,7 @@
       "type": "object"
     },
     "S": {
+      "additionalProperties": false,
       "properties": {
         "sprop": {
           "title": "Sprop",
@@ -41,6 +44,7 @@
       "type": "object"
     },
     "T": {
+      "additionalProperties": false,
       "properties": {
         "tprop": {
           "title": "Tprop",

--- a/src/acsets/schemas/jsonschema/PropertyReactionNet.json
+++ b/src/acsets/schemas/jsonschema/PropertyReactionNet.json
@@ -3,6 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "I": {
+      "additionalProperties": false,
       "properties": {
         "is": {
           "title": "Is",
@@ -17,6 +18,7 @@
       "type": "object"
     },
     "O": {
+      "additionalProperties": false,
       "properties": {
         "os": {
           "title": "Os",
@@ -31,6 +33,7 @@
       "type": "object"
     },
     "S": {
+      "additionalProperties": false,
       "properties": {
         "concentration": {
           "title": "Concentration",
@@ -45,6 +48,7 @@
       "type": "object"
     },
     "T": {
+      "additionalProperties": false,
       "properties": {
         "rate": {
           "title": "Rate",

--- a/src/acsets/schemas/jsonschema/ReactionNet.json
+++ b/src/acsets/schemas/jsonschema/ReactionNet.json
@@ -3,6 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "I": {
+      "additionalProperties": false,
       "properties": {
         "is": {
           "title": "Is",
@@ -17,6 +18,7 @@
       "type": "object"
     },
     "O": {
+      "additionalProperties": false,
       "properties": {
         "os": {
           "title": "Os",
@@ -31,6 +33,7 @@
       "type": "object"
     },
     "S": {
+      "additionalProperties": false,
       "properties": {
         "concentration": {
           "title": "Concentration",
@@ -41,6 +44,7 @@
       "type": "object"
     },
     "T": {
+      "additionalProperties": false,
       "properties": {
         "rate": {
           "title": "Rate",

--- a/src/acsets/schemas/jsonschema/SummationDecapode.json
+++ b/src/acsets/schemas/jsonschema/SummationDecapode.json
@@ -3,6 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Op1": {
+      "additionalProperties": false,
       "properties": {
         "op1": {
           "title": "Op1",
@@ -21,6 +22,7 @@
       "type": "object"
     },
     "Op2": {
+      "additionalProperties": false,
       "properties": {
         "op2": {
           "title": "Op2",
@@ -43,6 +45,7 @@
       "type": "object"
     },
     "Summand": {
+      "additionalProperties": false,
       "properties": {
         "summand": {
           "title": "Summand",
@@ -57,6 +60,7 @@
       "type": "object"
     },
     "TVar": {
+      "additionalProperties": false,
       "properties": {
         "incl": {
           "title": "Incl",
@@ -67,6 +71,7 @@
       "type": "object"
     },
     "Var": {
+      "additionalProperties": false,
       "properties": {
         "name": {
           "title": "Name",
@@ -81,6 +86,7 @@
       "type": "object"
     },
     "_": {
+      "additionalProperties": false,
       "properties": {
         "sum": {
           "title": "Sum",


### PR DESCRIPTION
This makes the JSON schema more strict, so we can make sure that objects are fully conforming when validating against the JSON schema and not including extraneous data